### PR TITLE
feat: Gradient Accmulation code 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,5 @@ outputs/
 configs/
 code_testing/
 log*.txt
+streamlit/
+deprecated/

--- a/base_config.json
+++ b/base_config.json
@@ -1,5 +1,6 @@
 {
     "name": "Baseline",
+    "root_dir": "/opt/ml/data",
     "seed": 21,
     "epochs": 250,
     "early_stop": 10,
@@ -7,12 +8,21 @@
     "log_interval": 20,
     "is_wandb": true,
     "is_debug": false,
+    "smp": {
+        "use": false,
+        "args": {
+            "encoder_name": "efficientnet-b7",
+            "encoder_weights": "imagenet",
+            "in_channels": 3,
+            "classes": 29
+        }
+    },
     "dataset": "XRayDataset",
     "augmentation": "CustomAugmentation",
-    "batch_size": 4,
+    "batch_size": 8,
+    "iters_to_accumulate": 4,
     "model": "UNet",
     "criterion": [
-        "cross_entropy",
         "focal",
         "bce_with_logit",
         "dice",
@@ -25,8 +35,8 @@
     "optimizer": {
         "type": "AdamW",
         "args": {
-            "lr": 5e-4,
-            "weight_decay": 5e-5
+            "lr": 1e-4,
+            "weight_decay": 1e-5
         }
     },
     "lr_scheduler": {
@@ -38,5 +48,5 @@
             "verbose": true
         }
     },
-    "num_workers": 8
+    "num_workers": 4
 }

--- a/train.py
+++ b/train.py
@@ -7,17 +7,19 @@ import re
 from importlib import import_module
 from pathlib import Path
 
+import albumentations as albu
 import numpy as np
+import segmentation_models_pytorch as smp
 import torch
-import wandb
-from losses.base_loss import DiceCoef, create_criterion
+from segmentation_models_pytorch.encoders import get_preprocessing_fn
 from torch import cuda
 from torch.utils.data import DataLoader
+
+import wandb
+from losses.base_loss import DiceCoef, create_criterion
 from trainer.trainer import Trainer
 from utils.util import ensure_dir
-import segmentation_models_pytorch as smp
-from segmentation_models_pytorch.encoders import get_preprocessing_fn
-import albumentations as albu
+
 
 def str2bool(v):
     if isinstance(v, bool):
@@ -58,7 +60,10 @@ def parse_args():
         "--augmentation", type=str, default=config["augmentation"], help="dataset augmentation type (default: BaseAugmentation)"
     )
     # parser.add_argument("--resize", type=list, default=config["resize"], help="img resize shape (default: [512,512])")
-    parser.add_argument("--batch_size", type=int, default=config["batch_size"], help="input batch size for training (default: 64)")
+    parser.add_argument("--batch_size", type=int, default=config["batch_size"], help="input batch size for training (default: 8)")
+    parser.add_argument(
+        "--iters_to_accumulate", type=int, default=config["iters_to_accumulate"], help="gradient update frequency (default: 4)"
+    )
 
     parser.add_argument("--model", type=str, default=config["model"], help="model type (default: UNet)")
     parser.add_argument("--criterion", type=str, default=config["criterion"], help="criterion type (default: bce_with_logit)")
@@ -68,7 +73,7 @@ def parse_args():
     parser.add_argument("--num_workers", type=int, default=config["num_workers"])
 
     args = parser.parse_args()
-    args.smp['use'] = str2bool(args.smp['use'])
+    args.smp["use"] = str2bool(args.smp["use"])
     if args.is_debug:
         args.epochs = 2
     print(args)
@@ -84,7 +89,6 @@ def seed_everything(seed):
     torch.backends.cudnn.benchmark = False
     np.random.seed(seed)
     random.seed(seed)
-    
 
 
 def increment_path(path, exist_ok=False):
@@ -104,25 +108,28 @@ def increment_path(path, exist_ok=False):
         n = max(i) + 1 if i else 2
         return f"{path}{n}"
 
+
 def to_tensor(x, **kwargs):
-    return x.transpose(2, 0, 1).astype('float32')
+    return x.transpose(2, 0, 1).astype("float32")
+
 
 def get_preprocessing(preprocessing_fn):
     """Construct preprocessing transform
-    
+
     Args:
-        preprocessing_fn (callbale): data normalization function 
+        preprocessing_fn (callbale): data normalization function
             (can be specific for each pretrained neural network)
     Return:
         transform: albumentations.Compose
-    
+
     """
-    
+
     _transform = [
         albu.Lambda(image=preprocessing_fn),
         albu.Lambda(image=to_tensor, mask=to_tensor),
     ]
     return albu.Compose(_transform)
+
 
 def main(args):
     if args.is_wandb:
@@ -141,20 +148,24 @@ def main(args):
 
     # -- model
     preprocess_input = None
-    if args.smp['use']:
+    if args.smp["use"]:
         model_module = getattr(smp, args.model)
-        model = model_module(**dict(args.smp['args'])).to(device)
-        preprocess_input = get_preprocessing_fn(args.smp['args']['encoder_name'], args.smp['args']['encoder_weights'])
+        model = model_module(**dict(args.smp["args"])).to(device)
+        preprocess_input = get_preprocessing_fn(args.smp["args"]["encoder_name"], args.smp["args"]["encoder_weights"])
     else:
         model_file_name = args.model.lower() + "_custom"  # custom
         model_name = "model." + model_file_name
         model_module = getattr(import_module(model_name), args.model)  # default: UNet
         model = model_module().to(device)
-        
+
     # -- dataset
     dataset_module = getattr(import_module("datasets.base_dataset"), args.dataset)  # default: XRayDataset
-    train_dataset = dataset_module(IMAGE_ROOT, LABEL_ROOT, is_train=True, is_debug = args.is_debug, preprocessing = get_preprocessing(preprocess_input))
-    valid_dataset = dataset_module(IMAGE_ROOT, LABEL_ROOT, is_train=False, is_debug = args.is_debug, preprocessing = get_preprocessing(preprocess_input))
+    train_dataset = dataset_module(
+        IMAGE_ROOT, LABEL_ROOT, is_train=True, is_debug=args.is_debug, preprocessing=get_preprocessing(preprocess_input)
+    )
+    valid_dataset = dataset_module(
+        IMAGE_ROOT, LABEL_ROOT, is_train=False, is_debug=args.is_debug, preprocessing=get_preprocessing(preprocess_input)
+    )
 
     # -- augmentation
     transform_module = getattr(import_module("datasets.augmentation"), args.augmentation)  # default: BaseAugmentation

--- a/trainer/base_trainer.py
+++ b/trainer/base_trainer.py
@@ -55,7 +55,7 @@ class BaseTrainer:
 
             # evaluate model performance according to configured metric, save best checkpoint as model_best
             if log["val_DiceCoef"] > best_val_dice:
-                print(f"New best model for val DiceCoef : {log['val_DiceCoef']:.4f}%! saving the best model..")
+                print(f"New best model for val DiceCoef : {log['val_DiceCoef']:.4f}! saving the best model..")
                 torch.save(self.model.state_dict(), f"{self.save_dir}/best_epoch.pth")
                 best_val_dice = log["val_DiceCoef"]
                 best_val_loss = log["val_Loss"]


### PR DESCRIPTION
 ## Overview
- bs를 늘려서 학습하기 위한 Gradient Accmulation code를 구현하였습니다.
  
---  
## Change log
- base_config에 필요한 인자를 추가하였습니다.
- train 과정을 loss를 accmulation 후, 원하는 step마다 update하는 방식으로 구현하였습니다.

---
## To Reviewer
- "batch_size": 8,
- "iters_to_accumulate": 4,

- base_config.json을 살펴보면, 다음과 같이 bs와 iters_to_accm 인자가 존재합니다
- batch_size는 한 번에 메모리에 올라갈 이미지 수로, nvidia-smi를 찍어보면서 적당한 값을 선정하면 됩니다.

- 다음으로 iters_to_accmulation은 update를 할 빈도로, bs=8, iters_to_accm=4로 설정된 경우, bs=32의 효과를 얻게 됩니다. 구현은 loss를 iters_to_accm로 나눠서 더하다가 iters_to_accm만큼 step이 돈 경우 update를 하는 방식입니다.
